### PR TITLE
Log transformers

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "scripts": {
     "clean": "rm -rf {build,dist} && mkdir dist",
     "compile": "babel src -d dist",
-    "deploy": "npm run clean && npm run compile && node-lambda deploy -e production",
+    "deploy": "npm run clean && npm run update-geoip && npm run compile && node-lambda deploy -e production",
     "lint": "eslint --config .eslintrc.js src test",
     "local": "npm run compile && node-lambda run",
-    "package": "npm run clean && npm run compile && node-lambda package -e production",
     "postinstall": "node-lambda setup",
-    "test": "mocha --compilers js:babel-core/register --reporter mocha-better-spec-reporter"
+    "test": "mocha --compilers js:babel-core/register --reporter mocha-better-spec-reporter --recursive",
+    "update-geoip": "node node_modules/geoip-lite/scripts/updatedb.js"
   },
   "repository": {
     "type": "git",
@@ -19,23 +19,24 @@
   "author": "BondLink <dev@bondlink.org>",
   "license": "Apache-2.0",
   "dependencies": {
-    "aws-sdk": "^2.91.0",
+    "@sendgrid/mail": "^6.1.2",
+    "aws-sdk": "^2.109.0",
+    "geoip-lite": "^1.2.1",
     "he": "^1.1.1",
-    "lambda-state": "github:mblink/lambda-state#0.0.1",
-    "sendgrid": "^5.2.0"
+    "lambda-state": "github:mblink/lambda-state#0.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
+    "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
-    "chai": "^4.1.0",
+    "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
-    "eslint": "^4.3.0",
+    "eslint": "^4.6.1",
     "eslint-config-airbnb": "^15.1.0",
     "eslint-plugin-import": "^2.7.0",
     "mocha": "^3.4.2",
     "mocha-better-spec-reporter": "^3.1.0",
     "node-lambda": "^0.11.3",
-    "sinon": "^2.4.1",
-    "sinon-chai": "^2.12.0"
+    "sinon": "^3.2.1",
+    "sinon-chai": "^2.13.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,23 @@
 import { CloudWatchLogs } from 'aws-sdk';
 import he from 'he';
-import sendgrid from 'sendgrid';
+import sendgrid from '@sendgrid/mail';
 import State from 'lambda-state';
+
+import jsonParse from './transformers/json-parse';
+import geolocate from './transformers/geolocate';
+import prettyPrint from './transformers/pretty-print';
+import htmlEncode from './transformers/html-encode';
+
+const transformers = [jsonParse, geolocate, prettyPrint, htmlEncode];
 
 const stackTrace = e => (e.stack || []).split('\n').slice(1).map(l => l.trim().replace(/^at /, ''));
 
 class CloudwatchLogsNotifier {
-  static createSendGridClient() { return sendgrid(process.env.SENDGRID_API_KEY); }
+  static setupSendGrid() { sendgrid.setApiKey(process.env.SENDGRID_API_KEY); return sendgrid; }
 
   constructor(event) {
     this.cwLogs = new CloudWatchLogs();
-    this.sendgrid = CloudwatchLogsNotifier.createSendGridClient();
+    this.sendgrid = CloudwatchLogsNotifier.setupSendGrid();
     this.message = JSON.parse(event.Records[0].Sns.Message);
 
     const ts = new Date(this.message.StateChangeTime);
@@ -73,42 +80,31 @@ class CloudwatchLogsNotifier {
   }
 
   buildEmail([params, events]) {
-    return new Promise((resolve) => {
-      const from = new sendgrid.mail.Email(process.env.FROM_EMAIL, 'AWS Lambda');
-      const to = new sendgrid.mail.Email(process.env.TO_EMAIL);
-      const subject = `ALARM: "${this.message.AlarmName}"`;
-      const logsUrl = 'https://console.aws.amazon.com/cloudwatch/home#logEventViewer:' +
-                        `group=${encodeURIComponent(params.logGroupName)};` +
-                        `filter=${encodeURIComponent(params.filterPattern)};` +
-                        `start=${encodeURIComponent(this.start.toISOString())};` +
-                        `end=${encodeURIComponent(this.end.toISOString())}`;
-      const messages = events.map((e) => {
-        let message;
-        try {
-          message = JSON.stringify(JSON.parse(e.message), null, 2);
-        } catch (_) {
-          message = e.message;
-        }
-        return he.encode(message);
+    return Promise.all(
+      events.map(e => transformers.reduce((acc, transformer) =>
+        acc.then(logLine => transformer(logLine)), Promise.resolve(e.message))))
+      .then((messages) => {
+        const logsUrl = 'https://console.aws.amazon.com/cloudwatch/home#logEventViewer:' +
+                          `group=${encodeURIComponent(params.logGroupName)};` +
+                          `filter=${encodeURIComponent(params.filterPattern)};` +
+                          `start=${encodeURIComponent(this.start.toISOString())};` +
+                          `end=${encodeURIComponent(this.end.toISOString())}`;
+        return {
+          to: process.env.TO_EMAIL,
+          from: { name: 'AWS Lambda', email: process.env.FROM_EMAIL },
+          subject: `ALARM: "${this.message.AlarmName}"`,
+          html: `Alarm: ${he.encode(this.message.AlarmName)}<br>
+            Time: ${he.encode(this.end.toString())}<br>
+            Logs:<br><br>
+            <pre>${messages.join('<hr>')}</pre>
+            <br>
+            <a href="${he.encode(logsUrl)}">View logs in CloudWatch</a>`
+        };
       });
-      const body = new sendgrid.mail.Content('text/html',
-        `Alarm: ${he.encode(this.message.AlarmName)}<br>
-        Time: ${he.encode(this.end.toString())}<br>
-        Logs:<br><br>
-        <pre>${messages.join('<hr>')}</pre>
-        <br>
-        <a href="${he.encode(logsUrl)}">View logs in CloudWatch</a>`);
-
-      resolve(new sendgrid.mail.Mail(from, subject, to, body));
-    });
   }
 
-  sendEmail(email) {
-    return this.sendgrid.API(this.sendgrid.emptyRequest({
-      method: 'POST',
-      path: '/v3/mail/send',
-      body: email.toJSON()
-    }));
+  sendEmail(message) {
+    return this.sendgrid.send(message);
   }
 }
 

--- a/src/transformers/geolocate.js
+++ b/src/transformers/geolocate.js
@@ -1,0 +1,7 @@
+import geoip from 'geoip-lite';
+
+export default logLine => new Promise(resolve =>
+  (Object.prototype.toString.call(logLine) === '[object Object]' &&
+      (Object.hasOwnProperty.call(logLine, 'forwarded-for-ip') || Object.hasOwnProperty.call(logLine, 'ip'))
+    ? resolve(Object.assign(logLine, { geolocation: geoip.lookup(logLine['forwarded-for-ip'] || logLine.ip) }))
+    : resolve(logLine)));

--- a/src/transformers/html-encode.js
+++ b/src/transformers/html-encode.js
@@ -1,0 +1,3 @@
+import he from 'he';
+
+export default logLine => Promise.resolve(he.encode(logLine));

--- a/src/transformers/json-parse.js
+++ b/src/transformers/json-parse.js
@@ -1,0 +1,3 @@
+export default logLine => new Promise((resolve) => {
+  try { resolve(JSON.parse(logLine)); } catch (e) { resolve(logLine); }
+});

--- a/src/transformers/pretty-print.js
+++ b/src/transformers/pretty-print.js
@@ -1,0 +1,7 @@
+export default logLine => new Promise((resolve) => {
+  if (typeof logLine === 'object') {
+    try { resolve(JSON.stringify(logLine, null, 2)); } catch (e) { resolve(logLine); }
+  } else {
+    resolve(logLine);
+  }
+});

--- a/test/stubs.js
+++ b/test/stubs.js
@@ -6,9 +6,12 @@ const CloudWatchLogs = {
   filterLogEvents(_, callback) { callback(null, { events: [] }); }
 };
 
-const sendgrid = {
-  emptyRequest(params) { return params; },
-  API() { return Promise.resolve({ statusCode: 200, body: 'test body', headers: ['test header'] }); }
+const geoip = {
+  lookup: 'test geolocation'
 };
 
-export { CloudWatchLogs, sendgrid };
+const sendgrid = {
+  send: Promise.resolve({ statusCode: 200, body: 'test body', headers: ['test header'] })
+};
+
+export { CloudWatchLogs, geoip, sendgrid };

--- a/test/transformers/geolocate-test.js
+++ b/test/transformers/geolocate-test.js
@@ -1,0 +1,46 @@
+import geoip from 'geoip-lite';
+import utils from '../setup';
+import geolocate from '../../src/transformers/geolocate';
+
+describe('geolocate', () => {
+  beforeEach(() => utils.stub(geoip, 'lookup').returns('test geolocation'));
+
+  describe('when the log line is an object', () => {
+    it('looks up geolocation data when the object has an "forwarded-for-ip" field', () =>
+      geolocate({ 'forwarded-for-ip': '1.1.1.1' }).then((parsed) => {
+        expect(geoip.lookup).to.have.been.calledOnce();
+        expect(geoip.lookup).to.have.been.calledWithExactly('1.1.1.1');
+        expect(parsed.geolocation).to.equal('test geolocation');
+      }));
+
+    it('looks up geolocation data when the object has an "ip" field', () =>
+      geolocate({ ip: '1.1.1.1' }).then((parsed) => {
+        expect(geoip.lookup).to.have.been.calledOnce();
+        expect(geoip.lookup).to.have.been.calledWithExactly('1.1.1.1');
+        expect(parsed.geolocation).to.equal('test geolocation');
+      }));
+
+    it('favors "forwarded-for-ip" over "ip"', () =>
+      geolocate({ 'forwarded-for-ip': '1.1.1.1', ip: '2.2.2.2' }).then((parsed) => {
+        expect(geoip.lookup).to.have.been.calledOnce();
+        expect(geoip.lookup).to.have.been.calledWithExactly('1.1.1.1');
+        expect(parsed.geolocation).to.equal('test geolocation');
+      }));
+
+    it('skips lookup when the object does not have an "ip" field', () =>
+      geolocate({ test: 'message' }).then((parsed) => {
+        expect(geoip.lookup).to.not.have.been.called();
+        expect(parsed.geolocation).to.be.undefined();
+      }));
+  });
+
+  describe('when the log line is not an object', () => {
+    const lines = { string: 'test', number: 1, boolean: true };
+    Object.keys(lines).forEach(type =>
+      it(`skips lookup when the log line is a ${type}`, () =>
+        geolocate(lines[type]).then((parsed) => {
+          expect(geoip.lookup).to.not.have.been.called();
+          expect(parsed.geolocation).to.be.undefined();
+        })));
+  });
+});

--- a/test/transformers/html-encode-test.js
+++ b/test/transformers/html-encode-test.js
@@ -1,0 +1,8 @@
+import '../setup';
+import htmlEncode from '../../src/transformers/html-encode';
+
+describe('htmlEncode', () => {
+  it('encodes special characters', () =>
+    htmlEncode('" & < >').then(parsed =>
+      expect(parsed).to.equal('&#x22; &#x26; &#x3C; &#x3E;')));
+});

--- a/test/transformers/json-parse-test.js
+++ b/test/transformers/json-parse-test.js
@@ -1,0 +1,13 @@
+import '../setup';
+import jsonParse from '../../src/transformers/json-parse';
+
+describe('jsonParse', () => {
+  it('parses JSON strings', () =>
+    jsonParse('{"test": "message"}').then(parsed => expect(parsed).to.deep.equal({ test: 'message' })));
+
+  it('returns the original for invalid JSON', () =>
+    jsonParse('{"test":').then(parsed => expect(parsed).to.equal('{"test":')));
+
+  it('returns the original for non-string values', () =>
+    jsonParse({ test: 'message' }).then(parsed => expect(parsed).to.deep.equal({ test: 'message' })));
+});

--- a/test/transformers/pretty-print-test.js
+++ b/test/transformers/pretty-print-test.js
@@ -1,0 +1,17 @@
+import '../setup';
+import prettyPrint from '../../src/transformers/pretty-print';
+
+describe('prettyPrint', () => {
+  const objects = {
+    object: { in: { test: 'message' }, out: '{\n  "test": "message"\n}' },
+    array: { in: ['test', 'message'], out: '[\n  "test",\n  "message"\n]' }
+  };
+  Object.keys(objects).forEach(type =>
+    it(`pretty prints ${type}s with two spaces`, () =>
+      prettyPrint(objects[type].in).then(parsed => expect(parsed).to.equal(objects[type].out))));
+
+  const nonObjects = { string: 'test', number: 1, boolean: true };
+  Object.keys(nonObjects).forEach(type =>
+    it(`skips pretty printing for ${type}s`, () =>
+      prettyPrint(nonObjects[type]).then(parsed => expect(parsed).to.equal(nonObjects[type]))));
+});


### PR DESCRIPTION
Adds log transformers for the following:

- Parsing JSON logs
- Geolocating ip addresses in JSON logs using [geoip-lite](https://github.com/bluesmoon/node-geoip)
- HTML encoding log messages
- Pretty printing parsed JSON logs